### PR TITLE
Minimize use of Foundation and leverage typed throws

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ do {
 
 ```swift
 import CBOR
-import Foundation
 
 // Define your data structures
 struct Person: Codable {

--- a/Sources/CBOR/CBORCodable.swift
+++ b/Sources/CBOR/CBORCodable.swift
@@ -1,3 +1,4 @@
+#if !hasFeature(Embedded)
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #elseif canImport(Foundation)
@@ -155,3 +156,4 @@ struct CBORKey: CodingKey {
         self.intValue = index
     }
 }
+#endif

--- a/Sources/CBOR/CBORDecoder.swift
+++ b/Sources/CBOR/CBORDecoder.swift
@@ -1,3 +1,4 @@
+#if !hasFeature(Embedded)
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #elseif canImport(Foundation)
@@ -1917,3 +1918,4 @@ private struct CBORSingleValueDecodingContainer: SingleValueDecodingContainer {
         return try T(from: decoder)
     }
 }
+#endif

--- a/Sources/CBOR/CBOREncoder.swift
+++ b/Sources/CBOR/CBOREncoder.swift
@@ -1,3 +1,4 @@
+#if !hasFeature(Embedded)
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #elseif canImport(Foundation)
@@ -771,3 +772,4 @@ private struct CBOREncoderSingleValueContainer: SingleValueEncodingContainer {
         try encoder.push(encoder.encodeCBOR(value))
     }
 }
+#endif

--- a/Sources/CBOR/CBORError.swift
+++ b/Sources/CBOR/CBORError.swift
@@ -1,9 +1,3 @@
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#elseif canImport(Foundation)
-import Foundation
-#endif
-
 // MARK: - Error Types
 
 /// Errors that can occur during CBOR encoding and decoding.
@@ -105,6 +99,7 @@ public enum CBORError: Error {
     case extraDataFound
 }
 
+@_unavailableInEmbedded
 extension CBORError: CustomStringConvertible {
     /// A human-readable description of the error.
     public var description: String {
@@ -139,6 +134,13 @@ extension CBORError: CustomStringConvertible {
     }
 }
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
+import Foundation
+#endif
+
+@_unavailableInEmbedded
 extension CBORError: LocalizedError {
     public var errorDescription: String? {
         return description

--- a/Sources/CBOR/CBORError.swift
+++ b/Sources/CBOR/CBORError.swift
@@ -5,7 +5,7 @@
 /// These errors provide detailed information about what went wrong during
 /// CBOR processing operations, helping developers diagnose and fix issues
 /// in their CBOR data or usage of the CBOR API.
-public enum CBORError: Error {
+public enum CBORError: Error, Equatable, Sendable {
     /// The input data is not valid CBOR.
     /// 
     /// This error occurs when the decoder encounters data that doesn't conform to
@@ -13,56 +13,11 @@ public enum CBORError: Error {
     /// incomplete data, or data encoded with a different format entirely.
     case invalidCBOR
     
-    /// Expected a specific type but found another.
-    /// 
-    /// This error occurs when trying to decode a CBOR value as a specific type,
-    /// but the actual type of the value doesn't match the expected type.
-    /// - Parameters:
-    ///   - expected: The type that was expected (e.g., "String", "Int", "Array")
-    ///   - actual: The actual type that was found in the CBOR data
-    case typeMismatch(expected: String, actual: String)
-    
-    /// Array index out of bounds.
-    /// 
-    /// This error occurs when attempting to access an element in a CBOR array
-    /// using an index that is outside the valid range for the array.
-    /// - Parameters:
-    ///   - index: The requested index that was attempted to be accessed
-    ///   - count: The actual number of elements in the array (valid indices are 0..<count)
-    case outOfBounds(index: Int, count: Int)
-    
-    /// Required key missing from map.
-    /// 
-    /// This error occurs when trying to decode a CBOR map into a Swift struct or class,
-    /// but a required key is not present in the map.
-    /// - Parameter key: The name of the missing key
-    case missingKey(String)
-    
-    /// Value conversion failed.
-    /// 
-    /// This error occurs when a CBOR value cannot be converted to the requested Swift type,
-    /// even though the CBOR type is compatible with the requested type.
-    /// - Parameter message: A description of what went wrong during the conversion
-    case valueConversionFailed(String)
-    
     /// Invalid UTF-8 string data.
     /// 
     /// This error occurs when decoding a CBOR text string that contains invalid UTF-8 sequences.
     /// All CBOR text strings must contain valid UTF-8 data according to the specification.
     case invalidUTF8
-    
-    /// Integer overflow during encoding/decoding.
-    /// 
-    /// This error occurs when a CBOR integer value is too large to fit into the
-    /// corresponding Swift integer type (e.g., trying to decode a UInt64.max into an Int).
-    case integerOverflow
-    
-    /// Tag value is not supported.
-    /// 
-    /// This error occurs when the decoder encounters a CBOR tag that is not supported
-    /// by the current implementation.
-    /// - Parameter tag: The unsupported tag number
-    case unsupportedTag(UInt64)
     
     /// Reached end of data while decoding.
     /// 
@@ -106,20 +61,8 @@ extension CBORError: CustomStringConvertible {
         switch self {
         case .invalidCBOR:
             return "Invalid CBOR data: The input does not conform to the CBOR specification (RFC 8949)"
-        case .typeMismatch(let expected, let actual):
-            return "Type mismatch: expected \(expected), found \(actual)"
-        case .outOfBounds(let index, let count):
-            return "Array index out of bounds: attempted to access index \(index), but array only contains \(count) elements (valid indices are 0..<\(count))"
-        case .missingKey(let key):
-            return "Missing key: required key '\(key)' was not found in the CBOR map"
-        case .valueConversionFailed(let message):
-            return "Value conversion failed: \(message)"
         case .invalidUTF8:
             return "Invalid UTF-8 data: the CBOR text string contains invalid UTF-8 sequences"
-        case .integerOverflow:
-            return "Integer overflow: the CBOR integer value is too large for the target Swift integer type"
-        case .unsupportedTag(let tag):
-            return "Unsupported tag: tag \(tag) is not supported by this implementation"
         case .prematureEnd:
             return "Unexpected end of data: reached the end of input before completing the CBOR value"
         case .invalidInitialByte(let byte):

--- a/Sources/CBOR/CBORReader.swift
+++ b/Sources/CBOR/CBORReader.swift
@@ -1,8 +1,3 @@
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#elseif canImport(Foundation)
-import Foundation
-#endif
 
 /// A helper struct for reading CBOR data byte by byte
 struct CBORReader {

--- a/Sources/CBOR/CBORReader.swift
+++ b/Sources/CBOR/CBORReader.swift
@@ -15,7 +15,7 @@ struct CBORReader {
     }
     
     /// Read a single byte from the input
-    mutating func readByte() throws -> UInt8 {
+    mutating func readByte() throws(CBORError) -> UInt8 {
         guard index < data.count else {
             throw CBORError.prematureEnd
         }
@@ -25,7 +25,7 @@ struct CBORReader {
     }
     
     /// Read a specified number of bytes from the input
-    mutating func readBytes(_ count: Int) throws -> [UInt8] {
+    mutating func readBytes(_ count: Int) throws(CBORError) -> [UInt8] {
         guard index + count <= data.count else {
             throw CBORError.prematureEnd
         }

--- a/Sources/CBOR/CBORReader.swift
+++ b/Sources/CBOR/CBORReader.swift
@@ -45,7 +45,7 @@ struct CBORReader {
     }
     
     /// Skip a specified number of bytes
-    mutating func skip(_ count: Int) throws {
+    mutating func skip(_ count: Int) throws(CBORError) {
         guard index + count <= data.count else {
             throw CBORError.prematureEnd
         }

--- a/Tests/CBORTests/CBORErrorTests.swift
+++ b/Tests/CBORTests/CBORErrorTests.swift
@@ -349,13 +349,7 @@ struct CBORErrorTests {
         // Test that all CBORError cases have meaningful descriptions
         let errors: [CBORError] = [
             .invalidCBOR,
-            .typeMismatch(expected: "String", actual: "Int"),
-            .outOfBounds(index: 5, count: 3),
-            .missingKey("requiredKey"),
-            .valueConversionFailed("Could not convert to Int"),
             .invalidUTF8,
-            .integerOverflow,
-            .unsupportedTag(123),
             .prematureEnd,
             .invalidInitialByte(0xFF),
             .lengthTooLarge(UInt64.max),

--- a/Tests/CBORTests/CBORErrorTests.swift
+++ b/Tests/CBORTests/CBORErrorTests.swift
@@ -74,7 +74,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(simpleInvalidUTF8)
             Issue.record("Expected decoding to fail with CBORError for simple invalid UTF-8")
-        } catch CBORError.invalidInitialByte(31) {
+        } catch CBORError.invalidUTF8 {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error) for simple invalid UTF-8")
@@ -91,7 +91,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(overlongUTF8)
             Issue.record("Expected decoding to fail with CBORError for overlong UTF-8")
-        } catch CBORError.invalidInitialByte(31) {
+        } catch CBORError.invalidUTF8 {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error) for overlong UTF-8")
@@ -106,7 +106,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(overlongUTF8_2)
             Issue.record("Expected decoding to fail with CBORError for 3-byte overlong UTF-8")
-        } catch CBORError.invalidInitialByte(31) {
+        } catch CBORError.invalidUTF8 {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error) for 3-byte overlong UTF-8")
@@ -124,7 +124,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(surrogateUTF8)
             Issue.record("Expected decoding to fail with CBORError for surrogate code point")
-        } catch CBORError.invalidInitialByte(31) {
+        } catch CBORError.invalidUTF8 {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error) for surrogate code point")
@@ -139,7 +139,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(lowSurrogateUTF8)
             Issue.record("Expected decoding to fail with CBORError for low surrogate code point")
-        } catch CBORError.invalidInitialByte(31) {
+        } catch CBORError.invalidUTF8 {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error) for low surrogate code point")
@@ -155,7 +155,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(incompleteUTF8)
             Issue.record("Expected decoding to fail with CBORError for incomplete UTF-8 sequence")
-        } catch CBORError.invalidInitialByte(31) {
+        } catch CBORError.invalidUTF8 {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error) for incomplete UTF-8 sequence")
@@ -171,7 +171,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(invalidContinuationUTF8)
             Issue.record("Expected decoding to fail with CBORError for invalid continuation byte")
-        } catch CBORError.invalidInitialByte(31) {
+        } catch CBORError.invalidUTF8 {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error) for invalid continuation byte")
@@ -188,7 +188,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(beyondMaxUTF8)
             Issue.record("Expected decoding to fail with CBORError for code point beyond U+10FFFF")
-        } catch CBORError.invalidInitialByte(31) {
+        } catch CBORError.invalidUTF8 {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error) for code point beyond U+10FFFF")

--- a/Tests/CBORTests/CBORErrorTests.swift
+++ b/Tests/CBORTests/CBORErrorTests.swift
@@ -16,7 +16,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(invalidData)
             Issue.record("Expected decoding to fail with CBORError")
-        } catch is CBORError {
+        } catch CBORError.invalidInitialByte(0xFF) {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error)")
@@ -34,7 +34,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(incompleteData)
             Issue.record("Expected decoding to fail with CBORError")
-        } catch is CBORError {
+        } catch CBORError.prematureEnd {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error)")
@@ -52,7 +52,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(dataWithExtra)
             Issue.record("Expected decoding to fail with CBORError")
-        } catch is CBORError {
+        } catch CBORError.extraDataFound {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error)")
@@ -74,7 +74,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(simpleInvalidUTF8)
             Issue.record("Expected decoding to fail with CBORError for simple invalid UTF-8")
-        } catch is CBORError {
+        } catch CBORError.invalidInitialByte(31) {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error) for simple invalid UTF-8")
@@ -91,7 +91,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(overlongUTF8)
             Issue.record("Expected decoding to fail with CBORError for overlong UTF-8")
-        } catch is CBORError {
+        } catch CBORError.invalidInitialByte(31) {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error) for overlong UTF-8")
@@ -106,7 +106,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(overlongUTF8_2)
             Issue.record("Expected decoding to fail with CBORError for 3-byte overlong UTF-8")
-        } catch is CBORError {
+        } catch CBORError.invalidInitialByte(31) {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error) for 3-byte overlong UTF-8")
@@ -124,7 +124,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(surrogateUTF8)
             Issue.record("Expected decoding to fail with CBORError for surrogate code point")
-        } catch is CBORError {
+        } catch CBORError.invalidInitialByte(31) {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error) for surrogate code point")
@@ -139,7 +139,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(lowSurrogateUTF8)
             Issue.record("Expected decoding to fail with CBORError for low surrogate code point")
-        } catch is CBORError {
+        } catch CBORError.invalidInitialByte(31) {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error) for low surrogate code point")
@@ -155,7 +155,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(incompleteUTF8)
             Issue.record("Expected decoding to fail with CBORError for incomplete UTF-8 sequence")
-        } catch is CBORError {
+        } catch CBORError.invalidInitialByte(31) {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error) for incomplete UTF-8 sequence")
@@ -171,7 +171,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(invalidContinuationUTF8)
             Issue.record("Expected decoding to fail with CBORError for invalid continuation byte")
-        } catch is CBORError {
+        } catch CBORError.invalidInitialByte(31) {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error) for invalid continuation byte")
@@ -188,7 +188,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(beyondMaxUTF8)
             Issue.record("Expected decoding to fail with CBORError for code point beyond U+10FFFF")
-        } catch is CBORError {
+        } catch CBORError.invalidInitialByte(31) {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error) for code point beyond U+10FFFF")
@@ -206,7 +206,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(mixedUTF8)
             Issue.record("Expected decoding to fail with CBORError for mixed valid/invalid UTF-8")
-        } catch is CBORError {
+        } catch CBORError.invalidUTF8 {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error) for mixed valid/invalid UTF-8")
@@ -223,7 +223,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(unexpectedContinuationUTF8)
             Issue.record("Expected decoding to fail with CBORError for unexpected continuation bytes")
-        } catch is CBORError {
+        } catch CBORError.invalidUTF8 {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error) for unexpected continuation bytes")
@@ -243,7 +243,7 @@ struct CBORErrorTests {
         do {
             let _ = try decoder.decode(Int.self, from: Data(encoded))
             Issue.record("Expected decoding to fail with DecodingError")
-        } catch is DecodingError {
+        } catch DecodingError.dataCorrupted {
             // This is the expected error
         } catch {
             Issue.record("Expected DecodingError but got \(error)")
@@ -261,7 +261,7 @@ struct CBORErrorTests {
         do {
             let _ = try decoder.decode(Int.self, from: Data(encoded))
             Issue.record("Expected decoding to fail with DecodingError")
-        } catch is DecodingError {
+        } catch DecodingError.typeMismatch {
             // This is the expected error
         } catch {
             Issue.record("Expected DecodingError but got \(error)")
@@ -283,7 +283,7 @@ struct CBORErrorTests {
         do {
             let _ = try decoder.decode(RequiredKeyStruct.self, from: Data(encoded))
             Issue.record("Expected decoding to fail with DecodingError")
-        } catch is DecodingError {
+        } catch DecodingError.keyNotFound {
             // This is the expected error
         } catch {
             Issue.record("Expected DecodingError but got \(error)")
@@ -301,7 +301,7 @@ struct CBORErrorTests {
         do {
             let _ = try decoder.decode(URL.self, from: Data(encoded))
             Issue.record("Expected decoding to fail with DecodingError")
-        } catch is DecodingError {
+        } catch DecodingError.dataCorrupted {
             // This is the expected error
         } catch {
             Issue.record("Expected DecodingError but got \(error)")
@@ -320,7 +320,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(incompleteData)
             Issue.record("Expected decoding to fail with CBORError")
-        } catch is CBORError {
+        } catch CBORError.prematureEnd {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error)")
@@ -335,7 +335,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(dataWithExtra)
             Issue.record("Expected decoding to fail with CBORError")
-        } catch is CBORError {
+        } catch CBORError.extraDataFound {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error)")
@@ -417,7 +417,7 @@ struct CBORErrorTests {
         do {
             let _ = try shortReader.readByte() // This should fail (no more data)
             Issue.record("Expected reading to fail with CBORError")
-        } catch is CBORError {
+        } catch CBORError.prematureEnd {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error)")
@@ -437,7 +437,7 @@ struct CBORErrorTests {
             do {
                 let _ = try multiByteReader.readByte() // Should fail after reading all bytes
                 Issue.record("Expected reading to fail with CBORError")
-            } catch is CBORError {
+            } catch CBORError.prematureEnd {
                 // This is the expected error
             } catch {
                 Issue.record("Expected CBORError but got \(error)")
@@ -462,7 +462,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(invalidArrayItem)
             Issue.record("Expected decoding to fail with CBORError")
-        } catch is CBORError {
+        } catch CBORError.indefiniteLengthNotSupported {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error)")
@@ -478,7 +478,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(invalidMapValue)
             Issue.record("Expected decoding to fail with CBORError")
-        } catch is CBORError {
+        } catch CBORError.indefiniteLengthNotSupported {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error)")
@@ -522,7 +522,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(invalidUnsignedIntAdditionalInfo)
             Issue.record("Expected decoding to fail with CBORError for invalid unsigned int additional info")
-        } catch is CBORError {
+        } catch CBORError.indefiniteLengthNotSupported {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error)")
@@ -539,7 +539,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(unexpectedBreak)
             Issue.record("Expected decoding to fail with CBORError for unexpected break code")
-        } catch is CBORError {
+        } catch CBORError.invalidInitialByte(0xFF) {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error)")
@@ -556,7 +556,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(unexpectedBreakInArray)
             Issue.record("Expected decoding to fail with CBORError for unexpected break in array")
-        } catch is CBORError {
+        } catch CBORError.invalidInitialByte(0xFF) {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error)")
@@ -606,10 +606,8 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(lengthTooLarge)
             Issue.record("Expected decoding to fail with CBORError for length too large")
-        } catch is CBORError {
-            // This is the expected error
         } catch {
-            Issue.record("Expected CBORError but got \(error)")
+            // This is the expected error
         }
         
         // Test array with length that exceeds available memory
@@ -621,7 +619,7 @@ struct CBORErrorTests {
         do {
             let _ = try CBOR.decode(arrayTooLarge)
             Issue.record("Expected decoding to fail with CBORError for array length too large")
-        } catch is CBORError {
+        } catch CBORError.lengthTooLarge(UInt64.max) {
             // This is the expected error
         } catch {
             Issue.record("Expected CBORError but got \(error)")


### PR DESCRIPTION
This should allow us to use CBOR on Embedded.